### PR TITLE
remove deprecated data objects from documentation and function args

### DIFF
--- a/R/SSplotJABBAres.R
+++ b/R/SSplotJABBAres.R
@@ -44,7 +44,7 @@
 #' @importFrom r4ss save_png
 #'
 #' @export
-SSplotJABBAres <- function(ss3rep = ss3diags::simple,
+SSplotJABBAres <- function(ss3rep,
                            subplots = c("cpue", "len", "age", "size", "con")[1],
                            seas = NULL,
                            plot = TRUE,

--- a/R/SSplotModelcomp.R
+++ b/R/SSplotModelcomp.R
@@ -59,7 +59,7 @@
 #'
 #' @keywords ssplot hindcasting
 #'
-SSplotModelcomp <- function(summaryoutput = ss3diags::retroSimple,
+SSplotModelcomp <- function(summaryoutput,
                             plot = TRUE,
                             print = deprecated(),
                             print_plot = FALSE,

--- a/R/SSplotRunstest.R
+++ b/R/SSplotRunstest.R
@@ -101,7 +101,7 @@ ssruns_sig3 <- function(x, type = NULL, mixing = "less") {
 #' @export
 #'
 
-SSplotRunstest <- function(ss3rep = ss3diags::simple,
+SSplotRunstest <- function(ss3rep,
                            mixing = "less",
                            subplots = c("cpue", "len", "age", "size", "con")[1],
                            plot = TRUE,
@@ -424,7 +424,7 @@ SSplotRunstest <- function(ss3rep = ss3diags::simple,
 #'
 #' @export
 
-SSrunstest <- function(ss3rep = ss3diags::simple,
+SSrunstest <- function(ss3rep,
                        mixing = "less",
                        quants = c("cpue", "len", "age", "con")[1],
                        indexselect = NULL,

--- a/man/SSplotJABBAres.Rd
+++ b/man/SSplotJABBAres.Rd
@@ -5,7 +5,7 @@
 \title{Residual plot}
 \usage{
 SSplotJABBAres(
-  ss3rep = ss3diags::simple,
+  ss3rep,
   subplots = c("cpue", "len", "age", "size", "con")[1],
   seas = NULL,
   plot = TRUE,

--- a/man/SSplotModelcomp.Rd
+++ b/man/SSplotModelcomp.Rd
@@ -5,7 +5,7 @@
 \title{Compare Multiple SS Model Estimates}
 \usage{
 SSplotModelcomp(
-  summaryoutput = ss3diags::retroSimple,
+  summaryoutput,
   plot = TRUE,
   print = deprecated(),
   print_plot = FALSE,

--- a/man/SSplotRunstest.Rd
+++ b/man/SSplotRunstest.Rd
@@ -5,7 +5,7 @@
 \title{Residual Diagnostics}
 \usage{
 SSplotRunstest(
-  ss3rep = ss3diags::simple,
+  ss3rep,
   mixing = "less",
   subplots = c("cpue", "len", "age", "size", "con")[1],
   plot = TRUE,

--- a/man/SSrunstest.Rd
+++ b/man/SSrunstest.Rd
@@ -5,7 +5,7 @@
 \title{Residual Diagnostics Plot}
 \usage{
 SSrunstest(
-  ss3rep = ss3diags::simple,
+  ss3rep,
   mixing = "less",
   quants = c("cpue", "len", "age", "con")[1],
   indexselect = NULL,


### PR DESCRIPTION
Changed `ss3rep = ss3diags::simple` to `ss3rep` and `summaryoutput = ss3diags::retroSimple` to `summaryoutput` in function arguments because we are no longer keeping `ss3diags::simple` and `ss3diags::retroSimple` data objects in the package. This fixes the warnings caused during R CMD Check.